### PR TITLE
Recent PR bugs

### DIFF
--- a/components/shared/EmailLink.tsx
+++ b/components/shared/EmailLink.tsx
@@ -10,14 +10,9 @@ interface EmailLinkProps {
 }
 
 export function EmailLink({ email, displayText, className, children }: EmailLinkProps) {
-  const [localPart, domain] = email.split("@");
   return (
     <a
-      href="#"
-      onClick={(e) => {
-        e.preventDefault();
-        window.location.href = `mailto:${localPart}@${domain}`;
-      }}
+      href={`mailto:${email}`}
       className={className}
     >
       {children ?? (displayText ?? email)}

--- a/content/markdown.tsx
+++ b/content/markdown.tsx
@@ -398,12 +398,21 @@ function stripMarkdown(text: string) {
     .trim();
 }
 
+const FAQ_SECTION_HEADERS = [
+  "## Preguntas frecuentes",
+  "## FAQ",
+  "## Frequently Asked Questions",
+];
+
+function isFaqSectionHeader(line: string): boolean {
+  const trimmed = line.trim();
+  return FAQ_SECTION_HEADERS.some((h) => trimmed === h);
+}
+
 export function extractFaqs(content: string) {
   const lines = content.split("\n");
   const faqs: { question: string; answer: string }[] = [];
-  const faqSectionIndex = lines.findIndex(
-    (line) => line.trim() === "## Preguntas frecuentes"
-  );
+  const faqSectionIndex = lines.findIndex(isFaqSectionHeader);
 
   if (faqSectionIndex === -1) {
     return faqs;
@@ -414,7 +423,7 @@ export function extractFaqs(content: string) {
   while (i < lines.length) {
     const line = lines[i].trim();
 
-    if (line.startsWith("## ") && line !== "## Preguntas frecuentes") {
+    if (line.startsWith("## ") && !isFaqSectionHeader(line)) {
       break;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes `EmailLink` to correctly handle "open in new tab" and enhances `extractFaqs` to support English FAQ headings.

The `EmailLink` component previously used `href="#"` with an `onClick` handler for `mailto:`, which prevented "Open link in new tab" from working as expected. This PR changes `href` to directly use `mailto:${email}`. Additionally, `extractFaqs` now recognizes "## FAQ" and "## Frequently Asked Questions" to ensure proper JSON-LD extraction for bilingual content.

<div><a href="https://cursor.com/agents/bc-e0cd362d-a1e8-4f1d-b47b-793e7ca4fd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0cd362d-a1e8-4f1d-b47b-793e7ca4fd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->