### PR TITLE
fix: emails de cotización desde chatbot no llegaban

### DIFF
--- a/components/chatbot/ChatWindow.tsx
+++ b/components/chatbot/ChatWindow.tsx
@@ -98,7 +98,7 @@ export function ChatWindow({ onClose }: ChatWindowProps) {
       try {
         setLeadSent(true);
         const state = metadata.conversationState as Record<string, unknown> | undefined;
-        await fetch("/api/leads", {
+        const response = await fetch("/api/leads", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -112,6 +112,12 @@ export function ChatWindow({ onClose }: ChatWindowProps) {
             language: locale,
           }),
         });
+
+        if (!response.ok) {
+          const errBody = await response.json().catch(() => ({}));
+          console.error("[Lead Send Error] API returned", response.status, errBody);
+          setLeadSent(false); // Allow retry on failure
+        }
       } catch (error) {
         console.error("[Lead Send Error]", error);
         setLeadSent(false); // Allow retry on failure

--- a/lib/chatbot/scoring.ts
+++ b/lib/chatbot/scoring.ts
@@ -32,6 +32,8 @@ const BUDGET_TIMELINE_KEYWORDS = [
   'next quarter', 'proximo trimestre',
   'ready to start', 'listos para empezar',
   'as soon as possible', 'lo antes posible',
+  'cotizacion', 'cotizar', 'cotizaciones', 'quote', 'quotation', 'estimate', 'estimacion',
+  'propuesta', 'proposal', 'presupuesto',
 ];
 
 const C_LEVEL_TITLES = [
@@ -122,10 +124,16 @@ export function calculateLeadScore(leadData: Partial<LeadData>): number {
     leadData.painPoint || '',
     leadData.previousAttempts || '',
     leadData.decisionMakers || '',
+    leadData.service || '',
   ].join(' ');
 
   if (containsAny(allText, BUDGET_TIMELINE_KEYWORDS)) {
     score += 10;
+  }
+
+  // Solicitud explícita de cotización/propuesta (service suele contener esto)
+  if (leadData.service && containsAny(leadData.service, ['cotiz', 'quote', 'propuesta', 'presupuesto', 'estimate'])) {
+    score += 25;
   }
 
   if (leadData.painPoint && leadData.previousAttempts && leadData.decisionMakers) {
@@ -171,9 +179,14 @@ export function getScoreBreakdown(leadData: Partial<LeadData>): Record<string, n
     leadData.painPoint || '',
     leadData.previousAttempts || '',
     leadData.decisionMakers || '',
+    leadData.service || '',
   ].join(' ');
   if (containsAny(allText, BUDGET_TIMELINE_KEYWORDS)) {
     breakdown['Budget/Timeline Mentioned'] = 10;
+  }
+
+  if (leadData.service && containsAny(leadData.service, ['cotiz', 'quote', 'propuesta', 'presupuesto', 'estimate'])) {
+    breakdown['Quote/Proposal Request'] = 25;
   }
 
   if (leadData.painPoint && leadData.previousAttempts && leadData.decisionMakers) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

Las solicitudes de cotización enviadas a través del chatbot no generaban emails a los destinatarios configurados.

## Causa raíz

El sistema de leads solo envía el email cuando:
1. **Score >= 30** (LEAD_SCORE_THRESHOLD)
2. **Al menos 3 mensajes** del usuario

El scoring **no reconocía** palabras como "cotización", "cotizar", "propuesta" ni el campo `service` (donde se extrae "quiero cotizar X"). Una conversación típica de cotización podía quedar con solo 5 puntos (por email) y nunca disparar el envío.

## Emails configurados

| Origen | Destinatarios | From |
|-------|---------------|------|
| Leads (chatbot) | `contacto@lx3.ai`, `carlos.irigoyen@gmail.com` | `leads@lx3.ai` |
| Formulario contacto | `carlos.irigoyen@gmail.com` | `contacto@lx3.ai` |

**Requisito:** `RESEND_API_KEY` debe estar configurado en el entorno para que los emails se envíen.

## Cambios realizados

1. **Scoring** (`lib/chatbot/scoring.ts`):
   - Agregar keywords: cotización, cotizar, quote, propuesta, presupuesto, estimate
   - Incluir campo `service` en el cálculo (antes no se usaba)
   - Bonus +25 pts cuando `service` indica intención de cotización

2. **Manejo de errores** (`ChatWindow.tsx`):
   - Verificar respuesta de `/api/leads` y permitir retry si falla
   - Log de errores en consola para debugging

Con estos cambios, una conversación como "Hola, quiero una cotización, mi email es x@y.com" alcanza score 30+ y dispara el envío del lead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa1013b0-c18b-48bf-b95f-892b7b59a4d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa1013b0-c18b-48bf-b95f-892b7b59a4d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

